### PR TITLE
allow JSEN to be initialized from a type-erased JSEN instance

### DIFF
--- a/Sources/JSEN.swift
+++ b/Sources/JSEN.swift
@@ -31,6 +31,7 @@ public enum JSEN : Equatable {
         case let dictionary as [String:Any]:
             let jsenElements: [String:JSEN] = dictionary.compactMapValues { JSEN(from: $0) }
             self = .dictionary(jsenElements)
+        case let jsen as JSEN: self = jsen
         default: return nil
         }
     }

--- a/Tests/JSENTests.swift
+++ b/Tests/JSENTests.swift
@@ -61,6 +61,8 @@ final class JSENTests : XCTestCase {
         XCTAssertEqual(JSEN(from: array), .array([42]))
         let dictionary: Any? = [ "key" : 42 ]
         XCTAssertEqual(JSEN(from: dictionary), .dictionary(["key" : 42]))
+        let jsen: Any? = JSEN.int(42)
+        XCTAssertEqual(JSEN(from: jsen), .int(42))
     }
 
     func test_initializer_withNestedValues_shouldSucceed() {


### PR DESCRIPTION
Currently, `JSEN(from: jsen) -> nil`. This allows for `JSEN(from: jsen) -> jsen`. This is analogous to `Int(42) -> int`, not `-> nil`.

This allows the initializer to accept a `JSEN` instance that's been type-erased. This'll come up if the JSEN value has been passed through some function that erases it to `Any`. In my case, this came up when I passed my "JSON object" `[String: JSEN]` into an adaptor function that took `[String: Any]`.

Thanks for considering!